### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Call this first! get/set the options required to run. Passing in an object liter
     user: 'myUserId',
     pass: 'myPassWurd',
     swarmUrl: 'swarm.jquery.org',
-    spawnUrl: 'http://swarm.jquery.org/run',
+    spawnUrl: 'http://swarm.jquery.org/run/_SWARM_USERNAME_',
     verbose: false,
     kill: true,
     clientTimeout: 6000


### PR DESCRIPTION
Update README: Without the username parameter testswarm /run does not…
…hing (alternatively use /?state=run&username=_SWARM_USERNAME_) the former is just a nicer mod_rewrit'ten url
