### PR TITLE
Add Chrome 20.0 and Opera 12.0

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -16,6 +16,10 @@ var map = {
         name:'chrome',
         version:'19.0'
     },
+    'Chrome|20':{
+        name:'chrome',
+        version:'20.0b'
+    },
     // 'Firefox|3|5': Not in browserstack anymore
     'Firefox|3|6':{
         name:'firefox',
@@ -92,6 +96,10 @@ var map = {
     'Opera|11|60':{
         name:'opera',
         version:'11.6'
+    },
+    'Opera|12|0':{
+        name:'opera',
+        version:'12.0'
     },
     // 'Opera|12|0': No browserstack yet
     'Safari|4':{


### PR DESCRIPTION
Note: Chrome 20.0 is stable, but browserstack ID is still 20.0b, otherwise it doesn't work.
