### PR TITLE
API: Update to BrowserStack API v.3

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,5 @@
 {
 	"bitwise": true,
-	"camelcase": true,
 	"curly": true,
 	"eqeqeq": true,
 	"immed": true,

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a light weight integration layer between [TestSwarm](https://github.com/
 
 This script is currently compatible with:
 * [TestSwarm](https://github.com/jquery/testswarm) 1.0.0-alpha or higher
-* [BrowserStack API](https://github.com/browserstack/api) v1
+* [BrowserStack API](https://github.com/browserstack/api) v3
 
 ## Install
 --------------------------------------

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	},
 	"dependencies": {
 		"async": "0.1.x",
-		"browserstack": "~0.1.0",
+		"browserstack": "~1.0.1",
 		"colors": "~0.6.0",
 		"commander": "0.6.x",
 		"request": "2.9.x",

--- a/src/mapHelper.js
+++ b/src/mapHelper.js
@@ -7,12 +7,12 @@
  *   https://github.com/browserstack/api
  *   http://api.browserstack.com/2/browsers (requires authentication)
  */
-var browserstack, testswarm;
+var browserstack;
 
 // These are in the direction: browserstack -> testswarm-mapped.
 browserstack = {
-	'win': 'Windows',
-	'mac': 'Mac OS X',
+	'Windows': 'Windows',
+	'OS X': 'Mac OS X',
 	'android': 'Android',
 	'ios': 'iOS',
 	// BrowserStack puts device version inside device family.
@@ -22,6 +22,7 @@ browserstack = {
 	'iPad 3rd': 'iPad',
 	'iPad 3rd (6.0)': 'iPad',
 	'iPad 3rd (7.0)': 'iPad',
+	'iPad Mini': 'iPad',
 	'iPhone 3GS': 'iPhone',
 	'iPhone 4': 'iPhone',
 	'iPhone 4S': 'iPhone',
@@ -30,20 +31,6 @@ browserstack = {
 	'iPhone 5S': 'iPhone'
 };
 
-// These are in the direction: testswarm -> browsertack-mapped.
-testswarm = {
-	// BrowserStack API (v2) doesn't give different windows versions,
-	// so we'll have to use that for now. This is probably fine since
-	// BrowserStack does have different windows versions internally
-	// (e.g. IE 6 is WinXP, IE 10 is on Win8).
-	// This is needed to make "Safari 5.1 on Windows XP" in TestSwarm work.
-	'Windows XP': 'Windows',
-	'Windows Vista': 'Windows',
-	'Windows 7': 'Windows',
-	'Windows 8': 'Windows'
-};
-
 module.exports = {
-	browserstack: browserstack,
-	testswarm: testswarm
+	browserstack: browserstack
 };

--- a/src/testswarm-browserstack.js
+++ b/src/testswarm-browserstack.js
@@ -87,7 +87,7 @@ self = {
 			// Lazy init
 			if (!bsClient) {
 				bsClient = browserstack.createClient({
-					version: 2,
+					version: 3,
 					username: config.browserstack.user,
 					password: config.browserstack.pass
 				});
@@ -246,23 +246,21 @@ self = {
 				browserData.osFamily = mapHelper.browserstack[browser.os] || browser.os;
 				browserData.deviceFamily = mapHelper.browserstack[browser.device] || browser.device;
 
-				// BrowserStack API v2 has no version properties for OS, except when there is a device.
-				// And in that case it puts the os version in the browser version property...
-				parts = browser.version.split('.');
-				if (!browserData.deviceFamily) {
-					browserData.browserMajor = parts[0];
-					browserData.browserMinor = parts[1];
-					browserData.browserPatch = parts[2];
-				} else {
+				// Some os_version fields in BrowserStack API v3 are numbers but not all, e.g. there's XP
+				// and Opera uses resolutions.
+				if (/^([0-9]+\.)*[0-9]+$/.test(browser.os_version)) {
+					parts = browser.os_version.split('.');
 					browserData.osMajor = parts[0];
 					browserData.osMinor = parts[1];
 					browserData.osPatch = parts[2];
 				}
-
-				// Apply normalisation mapping
-				uaData.browserFamily = mapHelper.testswarm[uaData.browserFamily] || uaData.browserFamily;
-				uaData.osFamily = mapHelper.testswarm[uaData.osFamily] || uaData.osFamily;
-				uaData.deviceFamily = mapHelper.testswarm[uaData.deviceFamily] || uaData.deviceFamily;
+				// Some browsers have the browser_version field not defined.
+				if (browser.browser_version) {
+					parts = browser.browser_version.split('.');
+					browserData.browserMajor = parts[0];
+					browserData.browserMinor = parts[1];
+					browserData.browserPatch = parts[2];
+				}
 
 				// If the wildcard is used and a later precision variable is also
 				// defined, then this doesn't work (e.g. "major: 4, minor: 1*, patch: 2",


### PR DESCRIPTION
The third version of the API is needed for IE11 support.
