### PR TITLE
Update to the 4th version of the BrowserStack API

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "async": "0.1.x",
-    "browserstack": "~1.0.1",
+    "browserstack": "^1.3.1",
     "colors": "~0.6.0",
     "commander": "0.6.x",
     "request": "2.9.x",

--- a/src/testswarm-browserstack.js
+++ b/src/testswarm-browserstack.js
@@ -100,7 +100,7 @@ self = {
 			// Lazy init
 			if (!bsClient) {
 				bsClient = browserstack.createClient({
-					version: 3,
+					version: 4,
 					username: config.browserstack.user,
 					password: config.browserstack.pass
 				});


### PR DESCRIPTION
Also, update the browserstack npm package to the latest version so that
the 4th API version works. There are no breaking changes in this update
so it should "just work".

Fixes #43