### PR TITLE
Map "Chrome Mobile" to "Android Browser", skip browserFamily only if set to Chrome

### DIFF
--- a/src/mapHelper.js
+++ b/src/mapHelper.js
@@ -13,7 +13,8 @@
 module.exports = {
 	browserFamily: {
 		'Yandex Browser': 'yandex',
-		'Android': 'Android Browser'
+		'Android': 'Android Browser',
+		'Chrome Mobile': 'Android Browser'
 	},
 	osFamily: {
 		'Windows': 'Windows',

--- a/src/testswarm-browserstack.js
+++ b/src/testswarm-browserstack.js
@@ -380,11 +380,10 @@ self = {
 					// "Android Browser" (even the ones that use "Chrome Mobile" in Android 4.4+).
 					// Instead of mapping all this (which would require complicating mapHelper to
 					// map browserFamily "Chrome" to "Android Browser", if osFamily is "Android"),
-					// simply ignore browserFamily for Android and iOS.
-					if ( key === 'browserFamily' &&
-						tsUaSpec.osFamily === 'Android' &&
-						tsUaSpec.osMajor &&
-						tsUaSpec.osMinor
+					// simply ignore browserFamily for Android if it's set to "Chrome".
+					// "Android" & "Chrome Mobile" are both mapped to "Android Browser".
+					if ( key === 'browserFamily' && tsUaSpec.osFamily === 'Android' &&
+						value === 'Chrome'
 					) {
 						return;
 					}


### PR DESCRIPTION
This is necessary to be able to display the Chrome Mobile icon in TestSwarm
even if only the major version is provided on Android.