### PR TITLE
Skip browsers with non-numerical versions like Edge Insider Preview

### DIFF
--- a/src/testswarm-browserstack.js
+++ b/src/testswarm-browserstack.js
@@ -334,6 +334,14 @@ self = {
 					// browser versions.
 					// Example browser_version values: "80.0", "80.0 beta", "70.1.5"
 					versionMatch = bswDesc.browser_version.match( /([\d.]+)( [a-zA-Z]+)?/ );
+
+					// Skip browsers with non-numerical versions like Edge Insider Preview
+					// which has `browser_version` set to "insider preview".
+					if ( !versionMatch ) {
+						valid = false;
+						return;
+					}
+
 					bswUaSpec.isStable = !versionMatch[ 2 ];
 
 					parts = versionMatch[ 1 ].split( '.' );


### PR DESCRIPTION
BrowserStack has just started sharing Edge Insider Preview via its API. That
browser has `browser_version` set to "insider preview". This commit makes us
skip browsers with non-numerical versions like that. Currently, only Edge
Insider Preview violates this constraint and there's hardly any reason to
test in it - this is a preview of the legacy version of Edge which is not
receiving updates anymore.

This change is needed to stop crashing testswarm-browserstack completely when
the API contains a browser with such a non-conforming version.

I've already applied these changes manually on our Swarm host to unblock jQuery Core tests.